### PR TITLE
Add `protein translation` exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -335,6 +335,14 @@
         "difficulty": 4
       },
       {
+        "slug": "protein-translation",
+        "name": "Protein Translation",
+        "uuid": "33bca041-4f26-4d6a-ac4c-bcaf342d2472",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
         "slug": "high-scores",
         "name": "High Scores",
         "uuid": "803f7779-8a3f-4c4f-88d1-edf40f76f53e",

--- a/exercises/practice/protein-translation/.docs/instructions.md
+++ b/exercises/practice/protein-translation/.docs/instructions.md
@@ -1,0 +1,45 @@
+# Instructions
+
+Translate RNA sequences into proteins.
+
+RNA can be broken into three-nucleotide sequences called codons, and then translated to a protein like so:
+
+RNA: `"AUGUUUUCU"` => translates to
+
+Codons: `"AUG", "UUU", "UCU"`
+=> which become a protein with the following sequence =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+There are 64 codons which in turn correspond to 20 amino acids; however, all of the codon sequences and resulting amino acids are not important in this exercise.
+If it works for one codon, the program should work for all of them.
+However, feel free to expand the list in the test suite to include them all.
+
+There are also three terminating codons (also known as 'STOP' codons); if any of these codons are encountered (by the ribosome), all translation ends and the protein is terminated.
+
+All subsequent codons after are ignored, like this:
+
+RNA: `"AUGUUUUCUUAAAUG"` =>
+
+Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
+
+Protein: `"Methionine", "Phenylalanine", "Serine"`
+
+Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
+
+Below are the codons and resulting amino acids needed for the exercise.
+
+| Codon              | Amino Acid    |
+| :----------------- | :------------ |
+| AUG                | Methionine    |
+| UUU, UUC           | Phenylalanine |
+| UUA, UUG           | Leucine       |
+| UCU, UCC, UCA, UCG | Serine        |
+| UAU, UAC           | Tyrosine      |
+| UGU, UGC           | Cysteine      |
+| UGG                | Tryptophan    |
+| UAA, UAG, UGA      | STOP          |
+
+Learn more about [protein translation on Wikipedia][protein-translation].
+
+[protein-translation]: https://en.wikipedia.org/wiki/Translation_(biology)

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,0 +1,18 @@
+{
+  "authors": [
+    "glaxxie"
+  ],
+  "files": {
+    "solution": [
+      "protein-translation.ua"
+    ],
+    "test": [
+      "tests.ua"
+    ],
+    "example": [
+      ".meta/example.ua"
+    ]
+  },
+  "blurb": "Translate RNA sequences into proteins.",
+  "source": "Tyler Long"
+}

--- a/exercises/practice/protein-translation/.meta/example.ua
+++ b/exercises/practice/protein-translation/.meta/example.ua
@@ -1,0 +1,26 @@
+# Translate RNA sequences into proteins.
+
+Split ← |1 ⇌⍣{⍥((↘3)⟜(↙3))(-1⌈÷3)⊸⧻}{}
+CodonsArr ← |0 {
+  "AUG"
+  "UUU" "UUC"
+  "UUA" "UUG"
+  "UCU" "UCC" "UCA" "UCG"
+  "UAU" "UAC"
+  "UGU" "UGC"
+  "UGG"
+  "UAA" "UAG" "UGA"
+}
+ProteinsArr ← |0 {
+  "Methionine"
+  ."Phenylalanine"
+  ."Leucine"
+  ..."Serine"
+  ."Tyrosine"
+  ."Cysteine"
+  "Tryptophan"
+  .."STOP"
+}
+Translate ← |1 ⍣⊏$"error: Invalid codon" ⊗ Split :CodonsArr:ProteinsArr
+# Proteins ? RNA
+Proteins ← |1 ↙ ⊗ □"STOP" . Translate

--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -1,0 +1,106 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[2c44f7bf-ba20-43f7-a3bf-f2219c0c3f98]
+description = "Empty RNA sequence results in no proteins"
+
+[96d3d44f-34a2-4db4-84cd-fff523e069be]
+description = "Methionine RNA sequence"
+
+[1b4c56d8-d69f-44eb-be0e-7b17546143d9]
+description = "Phenylalanine RNA sequence 1"
+
+[81b53646-bd57-4732-b2cb-6b1880e36d11]
+description = "Phenylalanine RNA sequence 2"
+
+[42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4]
+description = "Leucine RNA sequence 1"
+
+[ac5edadd-08ed-40a3-b2b9-d82bb50424c4]
+description = "Leucine RNA sequence 2"
+
+[8bc36e22-f984-44c3-9f6b-ee5d4e73f120]
+description = "Serine RNA sequence 1"
+
+[5c3fa5da-4268-44e5-9f4b-f016ccf90131]
+description = "Serine RNA sequence 2"
+
+[00579891-b594-42b4-96dc-7ff8bf519606]
+description = "Serine RNA sequence 3"
+
+[08c61c3b-fa34-4950-8c4a-133945570ef6]
+description = "Serine RNA sequence 4"
+
+[54e1e7d8-63c0-456d-91d2-062c72f8eef5]
+description = "Tyrosine RNA sequence 1"
+
+[47bcfba2-9d72-46ad-bbce-22f7666b7eb1]
+description = "Tyrosine RNA sequence 2"
+
+[3a691829-fe72-43a7-8c8e-1bd083163f72]
+description = "Cysteine RNA sequence 1"
+
+[1b6f8a26-ca2f-43b8-8262-3ee446021767]
+description = "Cysteine RNA sequence 2"
+
+[1e91c1eb-02c0-48a0-9e35-168ad0cb5f39]
+description = "Tryptophan RNA sequence"
+
+[e547af0b-aeab-49c7-9f13-801773a73557]
+description = "STOP codon RNA sequence 1"
+
+[67640947-ff02-4f23-a2ef-816f8a2ba72e]
+description = "STOP codon RNA sequence 2"
+
+[9c2ad527-ebc9-4ace-808b-2b6447cb54cb]
+description = "STOP codon RNA sequence 3"
+
+[f4d9d8ee-00a8-47bf-a1e3-1641d4428e54]
+description = "Sequence of two protein codons translates into proteins"
+
+[dd22eef3-b4f1-4ad6-bb0b-27093c090a9d]
+description = "Sequence of two different protein codons translates into proteins"
+
+[d0f295df-fb70-425c-946c-ec2ec185388e]
+description = "Translate RNA strand into correct protein list"
+
+[e30e8505-97ec-4e5f-a73e-5726a1faa1f4]
+description = "Translation stops if STOP codon at beginning of sequence"
+
+[5358a20b-6f4c-4893-bce4-f929001710f3]
+description = "Translation stops if STOP codon at end of two-codon sequence"
+
+[ba16703a-1a55-482f-bb07-b21eef5093a3]
+description = "Translation stops if STOP codon at end of three-codon sequence"
+
+[4089bb5a-d5b4-4e71-b79e-b8d1f14a2911]
+description = "Translation stops if STOP codon in middle of three-codon sequence"
+
+[2c2a2a60-401f-4a80-b977-e0715b23b93d]
+description = "Translation stops if STOP codon in middle of six-codon sequence"
+
+[f6f92714-769f-4187-9524-e353e8a41a80]
+description = "Sequence of two non-STOP codons does not translate to a STOP codon"
+
+[1e75ea2a-f907-4994-ae5c-118632a1cb0f]
+description = "Non-existing codon can't translate"
+include = false
+
+[9eac93f3-627a-4c90-8653-6d0a0595bc6f]
+description = "Unknown amino acids, not part of a codon, can't translate"
+reimplements = "1e75ea2a-f907-4994-ae5c-118632a1cb0f"
+
+[9d73899f-e68e-4291-b1e2-7bf87c00f024]
+description = "Incomplete RNA sequence can't translate"
+
+[43945cf7-9968-402d-ab9f-b8a28750b050]
+description = "Incomplete RNA sequence can translate if valid until a STOP codon"
+include = false

--- a/exercises/practice/protein-translation/protein-translation.ua
+++ b/exercises/practice/protein-translation/protein-translation.ua
@@ -1,0 +1,3 @@
+# Translate RNA sequences into proteins.
+# Proteins ? RNA
+Proteins ← |1 ⊙(⍤ "Please implement Proteins" 0)

--- a/exercises/practice/protein-translation/tests.ua
+++ b/exercises/practice/protein-translation/tests.ua
@@ -1,0 +1,88 @@
+~ "protein-translation.ua" ~ Proteins
+
+# Empty RNA sequence results in no proteins
+⍤⤙≍ {} Proteins ""
+
+# Methionine RNA sequence
+⍤⤙≍ {"Methionine"} Proteins "AUG"
+
+# Phenylalanine RNA sequence 1
+⍤⤙≍ {"Phenylalanine"} Proteins "UUU"
+
+# Phenylalanine RNA sequence 2
+⍤⤙≍ {"Phenylalanine"} Proteins "UUC"
+
+# Leucine RNA sequence 1
+⍤⤙≍ {"Leucine"} Proteins "UUA"
+
+# Leucine RNA sequence 2
+⍤⤙≍ {"Leucine"} Proteins "UUG"
+
+# Serine RNA sequence 1
+⍤⤙≍ {"Serine"} Proteins "UCU"
+
+# Serine RNA sequence 2
+⍤⤙≍ {"Serine"} Proteins "UCC"
+
+# Serine RNA sequence 3
+⍤⤙≍ {"Serine"} Proteins "UCA"
+
+# Serine RNA sequence 4
+⍤⤙≍ {"Serine"} Proteins "UCG"
+
+# Tyrosine RNA sequence 1
+⍤⤙≍ {"Tyrosine"} Proteins "UAU"
+
+# Tyrosine RNA sequence 2
+⍤⤙≍ {"Tyrosine"} Proteins "UAC"
+
+# Cysteine RNA sequence 1
+⍤⤙≍ {"Cysteine"} Proteins "UGU"
+
+# Cysteine RNA sequence 2
+⍤⤙≍ {"Cysteine"} Proteins "UGC"
+
+# Tryptophan RNA sequence #
+⍤⤙≍ {"Tryptophan"} Proteins "UGG"
+
+# STOP codon RNA sequence 1
+⍤⤙≍ {} Proteins "UAA"
+
+# STOP codon RNA sequence 2
+⍤⤙≍ {} Proteins "UAG"
+
+# STOP codon RNA sequence 3
+⍤⤙≍ {} Proteins "UGA"
+
+# Sequence of two protein codons translates into proteins
+⍤⤙≍ {"Phenylalanine" "Phenylalanine"} Proteins "UUUUUU"
+
+# Sequence of two different protein codons translates into proteins
+⍤⤙≍ {"Leucine" "Leucine"} Proteins "UUAUUG"
+
+# Translate RNA strand into correct protein list
+⍤⤙≍ {"Methionine" "Phenylalanine" "Tryptophan"} Proteins "AUGUUUUGG"
+
+# Translation stops if STOP codon at beginning of sequence
+⍤⤙≍ {} Proteins "UAGUGG"
+
+# Translation stops if STOP codon at end of two-codon sequence
+⍤⤙≍ {"Tryptophan"} Proteins "UGGUAG"
+
+# Translation stops if STOP codon at end of three-codon sequence
+⍤⤙≍ {"Methionine" "Phenylalanine"} Proteins "AUGUUUUAA"
+
+# Translation stops if STOP codon in middle of three-codon sequence
+⍤⤙≍ {"Tryptophan"} Proteins "UGGUAGUGG"
+
+# Translation stops if STOP codon in middle of six-codon sequence
+⍤⤙≍ {"Tryptophan" "Cysteine" "Tyrosine"} Proteins "UGGUGUUAUUAAUGGUUU"
+
+# Sequence of two non-STOP codons does not translate to a STOP codon
+⍤⤙≍ {"Methionine" "Methionine"} Proteins "AUGAUG"
+
+# Unknown amino acids not part of a codon can't translate
+⍤⤙≍ "error: Invalid codon" Proteins "XYZ"
+
+# Incomplete RNA sequence can't translate
+⍤⤙≍ "error: Invalid codon" Proteins "AUGU"


### PR DESCRIPTION
- Add exercise `protein translation` to UIUA track

Based on the spec, the last test  `Incomplete RNA sequence can translate if valid until a STOP codon` could be excluded to make the exercise simpler, so I chose to exclude it. It made the exercise way more complicated in my opinion.
I still keep the two tests when an incomplete RNA sequence can't translate and will throw an error.