### PR TITLE
feat: add difficulty suggester

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,28 @@
+# Track Tooling
+
+This document explains some of the additional helpers that compliment the usual tools for exercism tracks like configlet.
+
+## Difficulty-Suggester
+
+To help in difficulty grading of exercises, you can run `bin/difficulty_suggester plain`.
+The tool can print the suggestions in json format, to facilitate automation.
+
+### Workflow
+
+- Run  `bin/difficulty_suggester json > suggestions.json` in root.
+- Execute the jq code to update the suggestions and sort them alphabetically:
+
+    ```jq
+    jq --argfile suggestions suggestions.json '
+    .exercises.practice |= (
+        map(
+        .difficulty = ($suggestions[.slug]?.difficulty // .difficulty)
+        )
+        | sort_by(.difficulty, .slug)
+    )
+    ' config.json > updated_config.json
+    ```
+
+### Fine-Tuning
+
+Adjust the tokens.py file for a complexity-based evaluation of each glyph.

--- a/bin/difficulty_suggester
+++ b/bin/difficulty_suggester
@@ -5,26 +5,7 @@ import os
 import json
 from collections import Counter
 
-
-# Define valid tokens with complexity factors, start with 1.0 for all
-VALID_TOKENS = {
-    "◠": 1.0, "⌵": 1.0, "+": 1.0, "⌝": 1.0, "’": 1.0, "⍤": 1.0, "∠": 1.0,
-    "˜": 1.0, "◡": 1.0, "⋯": 1.0, "∩": 1.0, "□": 1.0, "⊓": 1.0, "⊸": 1.0,
-    "⍩": 1.0, "⌈": 1.0, "⑄": 1.0, "⊛": 1.0, "ℂ": 1.0, "◇": 1.0, "⊟": 1.0,
-    "◴": 1.0, "∂": 1.0, "♭": 1.0, "⊙": 1.0, "÷": 1.0, "⍢": 1.0, "↘": 1.0,
-    ".": 1.0, "∵": 1.0, "=": 1.0, "⍖": 1.0, "⬚": 1.0, "⌕": 1.0, "⊢": 1.0,
-    "¤": 1.0, ":": 1.0, "⌊": 1.0, "∧": 1.0, "⊃": 1.0, "⋅": 1.0, "≥": 1.0,
-    ">": 1.0, "⊕": 1.0, "∘": 1.0, "⊗": 1.0, "∫": 1.0, "⍚": 1.0, "⊂": 1.0,
-    "▽": 1.0, "⊣": 1.0, "⧻": 1.0, "≤": 1.0, "<": 1.0, "ₙ": 1.0, "⦷": 1.0,
-    "≍": 1.0, "↥": 1.0, "∊": 1.0, "∈": 1.0, "↧": 1.0, "◿": 1.0, "×": 1.0,
-    "¯": 1.0, "¬": 1.0, "≠": 1.0, "⌅": 1.0, "⤚": 1.0, "⟜": 1.0, "⤸": 1.0,
-    "⋕": 1.0, "⊜": 1.0, "⊡": 1.0, "◌": 1.0, "ⁿ": 1.0, "⚂": 1.0, "⇡": 1.0,
-    "/": 1.0, "⍥": 1.0, "☇": 1.0, "↯": 1.0, "⇌": 1.0, "⍏": 1.0, "↻": 1.0,
-    "⁅": 1.0, "≡": 1.0, "⊏": 1.0, "△": 1.0, "±": 1.0, "∿": 1.0, "⍆": 1.0,
-    "√": 1.0, "\\": 1.0, "?": 1.0, "-": 1.0, "⨬": 1.0, "⊞": 1.0, "↙": 1.0,
-    "⸮": 1.0, "⍉": 1.0, "◹": 1.0, "⍣": 1.0, "⧅": 1.0, "°": 1.0, "⍜": 1.0,
-    "◰": 1.0, "⊚": 1.0, "◫": 1.0, "⤙": 1.0
-}
+from tokens import VALID_TOKENS
 
 
 def tokenize_file(file_path):
@@ -114,10 +95,11 @@ def assign_difficulties(repo_path):
 
     return sorted_results
 
+
 def print_results(results, format="plain"):
     """
     Prints results in the specified format.
-    
+
     Args:
         results (dict): The results to print, where keys are exercise names and values contain difficulty data.
         format (str): The format to print the results in ("plain", "markdown", "json").
@@ -146,7 +128,8 @@ def print_results(results, format="plain"):
 
 if __name__ == "__main__":
     # Set up argparse for command-line interaction
-    parser = argparse.ArgumentParser(description="Assign difficulties to exercises and print the results.")
+    parser = argparse.ArgumentParser(
+        description="Assign difficulties to exercises and print the results.")
     parser.add_argument(
         "format",
         choices=["plain", "markdown", "json"],

--- a/bin/difficulty_suggester
+++ b/bin/difficulty_suggester
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import json
+from collections import Counter
+
+
+# Define valid tokens with complexity factors, start with 1.0 for all
+VALID_TOKENS = {
+    "◠": 1.0, "⌵": 1.0, "+": 1.0, "⌝": 1.0, "’": 1.0, "⍤": 1.0, "∠": 1.0,
+    "˜": 1.0, "◡": 1.0, "⋯": 1.0, "∩": 1.0, "□": 1.0, "⊓": 1.0, "⊸": 1.0,
+    "⍩": 1.0, "⌈": 1.0, "⑄": 1.0, "⊛": 1.0, "ℂ": 1.0, "◇": 1.0, "⊟": 1.0,
+    "◴": 1.0, "∂": 1.0, "♭": 1.0, "⊙": 1.0, "÷": 1.0, "⍢": 1.0, "↘": 1.0,
+    ".": 1.0, "∵": 1.0, "=": 1.0, "⍖": 1.0, "⬚": 1.0, "⌕": 1.0, "⊢": 1.0,
+    "¤": 1.0, ":": 1.0, "⌊": 1.0, "∧": 1.0, "⊃": 1.0, "⋅": 1.0, "≥": 1.0,
+    ">": 1.0, "⊕": 1.0, "∘": 1.0, "⊗": 1.0, "∫": 1.0, "⍚": 1.0, "⊂": 1.0,
+    "▽": 1.0, "⊣": 1.0, "⧻": 1.0, "≤": 1.0, "<": 1.0, "ₙ": 1.0, "⦷": 1.0,
+    "≍": 1.0, "↥": 1.0, "∊": 1.0, "∈": 1.0, "↧": 1.0, "◿": 1.0, "×": 1.0,
+    "¯": 1.0, "¬": 1.0, "≠": 1.0, "⌅": 1.0, "⤚": 1.0, "⟜": 1.0, "⤸": 1.0,
+    "⋕": 1.0, "⊜": 1.0, "⊡": 1.0, "◌": 1.0, "ⁿ": 1.0, "⚂": 1.0, "⇡": 1.0,
+    "/": 1.0, "⍥": 1.0, "☇": 1.0, "↯": 1.0, "⇌": 1.0, "⍏": 1.0, "↻": 1.0,
+    "⁅": 1.0, "≡": 1.0, "⊏": 1.0, "△": 1.0, "±": 1.0, "∿": 1.0, "⍆": 1.0,
+    "√": 1.0, "\\": 1.0, "?": 1.0, "-": 1.0, "⨬": 1.0, "⊞": 1.0, "↙": 1.0,
+    "⸮": 1.0, "⍉": 1.0, "◹": 1.0, "⍣": 1.0, "⧅": 1.0, "°": 1.0, "⍜": 1.0,
+    "◰": 1.0, "⊚": 1.0, "◫": 1.0, "⤙": 1.0
+}
+
+
+def tokenize_file(file_path):
+    """Tokenizes a file into valid symbols."""
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    return [char for char in content if char in VALID_TOKENS]
+
+
+def calculate_global_rarity(token_counts_list):
+    """Calculate global rarity for tokens across exercises."""
+    global_counts = Counter()
+    for token_counts in token_counts_list:
+        global_counts.update(token_counts)
+    total_exercises = len(token_counts_list)
+    return {
+        token: (1 / (count / total_exercises))
+        for token, count in global_counts.items()
+    }
+
+
+def calculate_raw_difficulty(token_counts, global_rarity):
+    """Calculate raw difficulty based on token rarity."""
+    if not token_counts:
+        return 0, 0, (0, 0)
+    # More complex tokens have bigger impact on difficulty
+    rarities_and_complexity = [global_rarity.get(
+        token, 0) * VALID_TOKENS.get(token, 1.0) for token in token_counts]
+    avg_rarity = sum(rarities_and_complexity) / len(rarities_and_complexity)
+    return avg_rarity * len(rarities_and_complexity), len(token_counts), (min(rarities_and_complexity), max(rarities_and_complexity))
+
+
+def normalize_difficulty(raw_difficulties, target_range=(1, 9)):
+    """Normalize raw difficulties to a target range."""
+    min_diff, max_diff = min(raw_difficulties), max(raw_difficulties)
+    scale = (target_range[1] - target_range[0]) / (max_diff - min_diff or 1)
+    return [
+        target_range[0] + scale * (difficulty - min_diff)
+        for difficulty in raw_difficulties
+    ]
+
+
+def assign_difficulties(repo_path):
+    """Main function to assign difficulty to exercises."""
+    exercises_path = os.path.join(repo_path, "uiua/exercises/practice")
+    results = {}
+    token_counts_list = []
+
+    # Collect token counts for all exercises
+    for exercise in os.listdir(exercises_path):
+        example_path = os.path.join(
+            exercises_path, exercise, ".meta", "example.ua")
+        if os.path.exists(example_path):
+            tokens = tokenize_file(example_path)
+            token_counts = Counter(tokens)
+            token_counts_list.append(token_counts)
+            results[exercise] = {"token_counts": token_counts}
+
+    # Calculate global rarity
+    global_rarity = calculate_global_rarity(token_counts_list)
+
+    # Calculate difficulties
+    for exercise, data in results.items():
+        raw_difficulty, unique_tokens, rarity_range = calculate_raw_difficulty(
+            data["token_counts"], global_rarity
+        )
+        results[exercise].update({
+            "raw_difficulty": raw_difficulty,
+            "unique_tokens": unique_tokens,
+            "rarity_range": rarity_range,
+        })
+
+    # Normalize difficulties
+    raw_difficulties = [data["raw_difficulty"] for data in results.values()]
+    normalized_difficulties = normalize_difficulty(raw_difficulties)
+
+    for exercise, normalized in zip(results.keys(), normalized_difficulties):
+        results[exercise]["difficulty"] = round(normalized)
+
+    # Sort results by difficulty
+    sorted_results = {
+        exercise: data
+        for exercise, data in sorted(
+            results.items(), key=lambda x: x[1]["difficulty"]
+        )
+    }
+
+    return sorted_results
+
+def print_results(results, format="plain"):
+    """
+    Prints results in the specified format.
+    
+    Args:
+        results (dict): The results to print, where keys are exercise names and values contain difficulty data.
+        format (str): The format to print the results in ("plain", "markdown", "json").
+    """
+    if format == "plain":
+        for exercise, data in results.items():
+            print(f"{exercise}:")
+            print(f"  Difficulty: {data['difficulty']}")
+            print(f"  Unique Tokens: {data['unique_tokens']}")
+            print(f"  Rarity Range: {data['rarity_range']}")
+            print("-" * 40)
+
+    elif format == "markdown":
+        print("| Exercise | Difficulty | Unique Tokens | Rarity Range |")
+        print("|----------|------------|---------------|--------------|")
+        for exercise, data in results.items():
+            print(
+                f"| {exercise} | {data['difficulty']} | {data['unique_tokens']} | {data['rarity_range']} |"
+            )
+
+    elif format == "json":
+        print(json.dumps(results, indent=4))
+    else:
+        print("Unsupported format. Please choose 'plain', 'markdown', or 'json'.")
+
+
+if __name__ == "__main__":
+    # Set up argparse for command-line interaction
+    parser = argparse.ArgumentParser(description="Assign difficulties to exercises and print the results.")
+    parser.add_argument(
+        "format",
+        choices=["plain", "markdown", "json"],
+        default="plain",
+        help="Specify the output format: 'plain' for plain text, 'markdown' for GitHub-flavored Markdown, or 'json' for JSON."
+    )
+    parser.add_argument(
+        "--repo-path",
+        default="../",
+        help="The path to the repository (default: '../')."
+    )
+
+    args = parser.parse_args()
+
+    # Use the provided arguments
+    result = assign_difficulties(args.repo_path)
+    print_results(result, format=args.format)

--- a/bin/tokens.py
+++ b/bin/tokens.py
@@ -1,0 +1,247 @@
+# TODO: modify suggestion program to use tokens with more than one character
+
+VALID_TOKENS = {
+    # 0 arguments, 0 outputs
+    # ----------------------------------------
+    "&ast": 1.0,  # Synthesize and stream audio
+    "?": 1.0,  # Debug print all stack values without popping them
+    "dump": 1.0,  # Preprocess and print all stack values without popping them
+
+    # 0 arguments, 1 outputs
+    # ----------------------------------------
+    "&args": 1.0,  # Get the command line arguments
+    "&asr": 1.0,  # Get the sample rate of the audio output backend
+    "&clip": 1.0,  # Get the contents of the clipboard
+    "&sc": 1.0,  # Read a line from stdin
+    "&ts": 1.0,  # Get the size of the terminal
+    "/": 1.0,  # Apply a reducing function to an array
+    "comptime": 1.0,  # Run a function at compile time
+    "memo": 1.0,  # Memoize a function
+    "now": 1.0,  # Get the current time in seconds
+    "pool": 1.0,  # Spawn a thread in a thread pool
+    "quote": 1.0,  # Convert a string into code at compile time
+    "spawn": 1.0,  # Spawn a thread
+    "stringify": 1.0,  # Convert code into a string instead of compiling it
+    "tag": 1.0,  # Generate a unique tag
+    "timezone": 1.0,  # Get the local timezone offset
+    "°": 1.0,  # Invert the behavior of a function
+    "η": 1.0,  # The number of radians in a quarter circle
+    "π": 1.0,  # The ratio of a circle's circumference to its diameter
+    "τ": 1.0,  # The ratio of a circle's circumference to its radius
+    "∂": 1.0,  # Calculate the derivative of a mathematical expression
+    "∞": 1.0,  # The biggest number
+    "∧": 1.0,  # Apply a function to aggregate arrays
+    "∩": 1.0,  # Call a function on two sets of values
+    "∫": 1.0,  # Calculate an antiderivative of a mathematical expression
+    "∵": 1.0,  # Apply a function to each element of an array or arrays
+    "≡": 1.0,  # Apply a function to each row of an array or arrays
+    "⊃": 1.0,  # Call two functions on the same values
+    "⊓": 1.0,  # Call two functions on two distinct sets of values
+    "⊙": 1.0,  # Temporarily pop the top value off the stack and call a function
+    "⊞": 1.0,  # Apply a function to each combination of rows of some arrays
+    "⊸": 1.0,  # Duplicate a function's last argument before calling it
+    "⋅": 1.0,  # Discard the top stack value then call a function
+    "⌅": 1.0,  # Define the various inverses of a function
+    "⌝": 1.0,  # Invert the behavior of a function, treating its first argument as a constant
+    "⍚": 1.0,  # Apply a function to each unboxed row of an array and re-box the results
+    "⍜": 1.0,  # Operate on a transformed array, then reverse the transformation
+    "⍢": 1.0,  # Repeat a function while a condition holds
+    "⍣": 1.0,  # Call a function and catch errors
+    "⍥": 1.0,  # Repeat a function a number of times
+    "⍩": 1.0,  # Call a pattern matching case
+    "◇": 1.0,  # Unbox the arguments to a function before calling it
+    "◠": 1.0,  # Keep all arguments to a function above the outputs on the stack
+    "◡": 1.0,  # Keep all arguments to a function below the outputs on the stack
+    "◹": 1.0,  # Apply a function to each shrinking row of an array
+    "⚂": 1.0,  # Generate a random number in the range [0, 1)
+    "⟜": 1.0,  # Call a function but keep its first argument on the top of the stack
+    "⤙": 1.0,  # Call a function but keep its last argument on the top of the stack
+    "⤚": 1.0,  # Call a function but keep its first argument under the outputs on the stack
+    "⧅": 1.0,  # Get permutations or combinations of an array
+    "⨬": 1.0,  # Call the function at the given index
+    "⬚": 1.0,  # Set the fill value for a function
+    "𝄈": 1.0,  # Call a function with its arguments reversed
+
+    # 0 arguments, 2 outputs
+    # ----------------------------------------
+    "astar": 1.0,  # Find shortest paths in a graph
+    "signature": 1.0,  # Get the signature of a function
+
+    # 1 arguments, 0 outputs
+    # ----------------------------------------
+    "&ap": 1.0,  # Play some audio
+    "&cd": 1.0,  # Change the current directory
+    "&cl": 1.0,  # Close a stream by its handle
+    "&ep": 1.0,  # Print a value to stderr followed by a newline
+    "&epf": 1.0,  # Print a value to stderr
+    "&exit": 1.0,  # Exit the program with a status code
+    "&fde": 1.0,  # Delete a file or directory
+    "&fmd": 1.0,  # Create a directory
+    "&ftr": 1.0,  # Move a file or directory to the trash
+    "&ims": 1.0,  # Show an image
+    "&memfree": 1.0,  # Free a pointer
+    "&p": 1.0,  # Print a value to stdout followed by a newline
+    "&pf": 1.0,  # Print a value to stdout
+    "&raw": 1.0,  # Set the terminal to raw mode
+    "&s": 1.0,  # Print a nicely formatted representation of a value to stdout
+    "&sl": 1.0,  # Sleep for n seconds
+    "◌": 1.0,  # Discard the top stack value
+
+    # 1 arguments, 1 outputs
+    # ----------------------------------------
+    "&camcap": 1.0,  # Capture an image from a webcam
+    "&fc": 1.0,  # Create a file and return a handle to it
+    "&fe": 1.0,  # Check if a file, directory, or symlink exists at a path
+    "&fif": 1.0,  # Check if a path is a file
+    "&fld": 1.0,  # List the contents of a directory
+    "&fo": 1.0,  # Open a file and return a handle to it
+    "&frab": 1.0,  # Read all the contents of a file into a byte array
+    "&fras": 1.0,  # Read all the contents of a file into a string
+    "&invk": 1.0,  # Invoke a path with the system's default program
+    "&runi": 1.0,  # Run a command and wait for it to finish
+    "&tcpa": 1.0,  # Accept a connection with a TCP or TLS listener
+    "&tcpaddr": 1.0,  # Get the connection address of a TCP socket
+    "&tcpc": 1.0,  # Create a TCP socket and connect it to an address
+    "&tcpl": 1.0,  # Create a TCP listener and bind it to an address
+    "&tcpsnb": 1.0,  # Set a TCP socket to non-blocking mode
+    "&tlsc": 1.0,  # Create a TCP socket with TLS support
+    "&tlsl": 1.0,  # Create a TLS listener and bind it to an address
+    "&var": 1.0,  # Get the value of an environment variable
+    "\\": 1.0,  # Reduce, but keep intermediate values
+    "binary": 1.0,  # Encode an array into a compact binary representation
+    "csv": 1.0,  # Encode an array into a CSV string
+    "datetime": 1.0,  # Get the date and time information from a time
+    "fft": 1.0,  # Run the Fast Fourier Transform on an array
+    "graphemes": 1.0,  # Convert a string to a list of UTF-8 grapheme clusters
+    "json": 1.0,  # Encode an array into a JSON string
+    "recv": 1.0,  # Receive a value from a thread
+    "repr": 1.0,  # Convert a value to its code representation
+    "tryrecv": 1.0,  # Try to receive a value from a thread
+    "type": 1.0,  # Check the type of an array
+    "utf₈": 1.0,  # Convert a string to UTF-8 bytes
+    "wait": 1.0,  # Wait for a thread to finish and push its results to the stack
+    "xlsx": 1.0,  # Encode an array into XLSX bytes
+    "¤": 1.0,  # Add a length-1 axis to an array
+    "¬": 1.0,  # Logical not
+    "¯": 1.0,  # Negate a number
+    "±": 1.0,  # Numerical sign (1, ¯1, or 0)
+    "⁅": 1.0,  # Round to the nearest integer
+    "⇌": 1.0,  # Reverse the rows of an array
+    "⇡": 1.0,  # Make an array of all natural numbers less than a number
+    "∘": 1.0,  # Do nothing with one value
+    "√": 1.0,  # Take the square root of a number
+    "∿": 1.0,  # Get the sine of a number
+    "⊚": 1.0,  # Get indices where array values are not equal to zero
+    "⊛": 1.0,  # Assign a unique index to each unique row in an array
+    "⊢": 1.0,  # Get the first row of an array
+    "⊣": 1.0,  # Get the last row of an array
+    "⋕": 1.0,  # Parse a string as a number
+    "⋯": 1.0,  # Encode an array as bits (LSB-first)
+    "⌈": 1.0,  # Round to the nearest integer towards ∞
+    "⌊": 1.0,  # Round to the nearest integer towards ¯∞
+    "⌵": 1.0,  # Get the absolute value of a number
+    "⍆": 1.0,  # Sort an array
+    "⍉": 1.0,  # Rotate the shape of an array
+    "⍏": 1.0,  # Get the indices into an array if it were sorted ascending
+    "⍖": 1.0,  # Get the indices into an array if it were sorted descending
+    "□": 1.0,  # Turn an array into a box
+    "△": 1.0,  # Get the dimensions of an array
+    "◰": 1.0,  # Get a mask of first occurrences of items in an array
+    "◴": 1.0,  # Remove duplicate rows from an array
+    "♭": 1.0,  # Make an array 1-dimensional
+    "⧻": 1.0,  # Get the number of rows in an array
+    "⸮": 1.0,  # Debug print the top value on the stack without popping it
+
+    # 1 arguments, 2 outputs
+    # ----------------------------------------
+    ".": 1.0,  # Duplicate the top value on the stack
+
+    # 1 arguments, 3 outputs
+    # ----------------------------------------
+    "&runc": 1.0,  # Run a command and wait for it to finish
+    "&runs": 1.0,  # Run a command with streaming IO
+
+    # 2 arguments, 0 outputs
+    # ----------------------------------------
+    "&fwa": 1.0,  # Write the entire contents of an array to a file
+    "&gifs": 1.0,  # Show a gif
+    "&tcpsrt": 1.0,  # Set the read timeout of a TCP socket in seconds
+    "&tcpswt": 1.0,  # Set the write timeout of a TCP socket in seconds
+    "&w": 1.0,  # Write an array to a stream
+    "send": 1.0,  # Send a value to a thread
+    "⍤": 1.0,  # Throw an error if a condition is not met
+
+    # 2 arguments, 1 outputs
+    # ----------------------------------------
+    "&ffi": 1.0,  # Call a foreign function interface
+    "&httpsw": 1.0,  # Make an HTTP(S) request
+    "&rb": 1.0,  # Read at most n bytes from a stream
+    "&rs": 1.0,  # Read characters formed by at most n bytes from a stream
+    "&ru": 1.0,  # Read from a stream until a delimiter is reached
+    "+": 1.0,  # Add values
+    "-": 1.0,  # Subtract values
+    "<": 1.0,  # Compare for less than
+    "=": 1.0,  # Compare for equality
+    ">": 1.0,  # Compare for greater than
+    "base": 1.0,  # Get the base digits of a number
+    "choose": 1.0,  # Get all combinations of k rows from an array
+    "gen": 1.0,  # Generate an array of random numbers with a seed
+    "get": 1.0,  # Get the value corresponding to a key in a map array
+    "gif": 1.0,  # Encode a gif into a byte array
+    "has": 1.0,  # Check if a map array has a key
+    "img": 1.0,  # Encode an image into a byte array with the specified format
+    "layout": 1.0,  # Render text into an image array
+    "map": 1.0,  # Create a hashmap from a list of keys and list values
+    "permute": 1.0,  # Get all permutations of k rows from an array
+    "regex": 1.0,  # Match a regex pattern
+    "remove": 1.0,  # Remove the value corresponding to a key from a map array
+    "×": 1.0,  # Multiply values
+    "÷": 1.0,  # Divide values
+    "ⁿ": 1.0,  # Raise a value to a power
+    "ₙ": 1.0,  # Get the based logarithm of a number
+    "ℂ": 1.0,  # Make a complex number
+    "↘": 1.0,  # Drop the first n rows of an array
+    "↙": 1.0,  # Take the first n rows of an array
+    "↥": 1.0,  # Take the maximum of two arrays
+    "↧": 1.0,  # Take the minimum of two arrays
+    "↯": 1.0,  # Change the shape of an array
+    "↻": 1.0,  # Rotate the elements of an array by n
+    "∈": 1.0,  # Check if each row of one array exists in another
+    "∊": 1.0,  # Check if each row of one array exists in another
+    "∠": 1.0,  # Take the arctangent of two numbers
+    "≍": 1.0,  # Check if two arrays are exactly the same
+    "≠": 1.0,  # Compare for inequality
+    "≤": 1.0,  # Compare for less than or equal
+    "≥": 1.0,  # Compare for greater than or equal
+    "⊂": 1.0,  # Append two arrays end-to-end
+    "⊏": 1.0,  # Select multiple rows from an array
+    "⊕": 1.0,  # Group elements of an array into buckets by index
+    "⊗": 1.0,  # Find the first index of each row of one array in another
+    "⊜": 1.0,  # Group sequential sections of an array
+    "⊟": 1.0,  # Combine two arrays as rows of a new array
+    "⊡": 1.0,  # Index a row or elements from an array
+    "⌕": 1.0,  # Find the occurences of one array in another
+    "⑄": 1.0,  # Get the n-wise chunks of an array
+    "▽": 1.0,  # Discard or copy some rows of an array
+    "◫": 1.0,  # The n-wise windows of an array
+    "◿": 1.0,  # Modulo values
+    "☇": 1.0,  # Change the rank of an array's rows
+    "⤸": 1.0,  # Change the order of the axes of an array
+    "⦷": 1.0,  # Mask the occurences of one array in another
+
+    # 2 arguments, 2 outputs
+    # ----------------------------------------
+    ":": 1.0,  # Swap the top two values on the stack
+
+    # 2 arguments, 3 outputs
+    # ----------------------------------------
+    ",": 1.0,  # Duplicate the second-to-top value to the top of the stack
+    "’": 1.0,  # Duplicate the top value on the stack to the third-to-top position
+
+    # 3 arguments, 1 outputs
+    # ----------------------------------------
+    "&memcpy": 1.0,  # Copy data from a pointer into an array
+    "audio": 1.0,  # Encode audio into a byte array
+    "insert": 1.0,  # Insert a key-value pair into a map array
+
+}


### PR DESCRIPTION
I don't know if this is very useful in the current state of the track, but I liked the challenge and made a difficulty-suggester utility that can provide markdown, plain, and JSON suggestions for the exercises on the track.

The heuristic I used is the frequency of the glyphs used across all the other exercises and the option to mark some glyphs as more complex in their usage to make the results more precise. If the results are nice, someone can use the JSON to integrate into the config file.

The current output looks like this:

| Exercise | Difficulty | Unique Tokens | Rarity Range |
|----------|------------|---------------|--------------|
| leap | 1 | 4 | (1.2142857142857144, 4.636363636363636) |
| hello-world | 1 | 0 | (0, 0) |
| rna-transcription | 1 | 2 | (1.02, 5.1) |
| gigasecond | 1 | 3 | (1.2142857142857144, 5.666666666666666) |
| resistor-color | 1 | 3 | (1.8214285714285712, 3.9230769230769234) |
| reverse-string | 2 | 3 | (1.02, 10.2) |
| collatz-conjecture | 2 | 9 | (0.5862068965517242, 5.1) |
| difference-of-squares | 2 | 6 | (1.2142857142857144, 7.285714285714285) |
| house | 2 | 11 | (0.5862068965517242, 3.6428571428571423) |
| two-fer | 2 | 6 | (0.5862068965517242, 8.5) |
| eliuds-eggs | 2 | 3 | (1.2142857142857144, 17.0) |
| nucleotide-count | 2 | 6 | (1.02, 10.2) |
| grains | 2 | 9 | (0.5862068965517242, 7.285714285714285) |
| acronym | 2 | 6 | (1.3421052631578947, 7.285714285714285) |
| scrabble-score | 2 | 6 | (1.02, 5.666666666666666) |
| resistor-color-duo | 2 | 8 | (1.2142857142857144, 8.5) |
| matrix | 3 | 9 | (0.5862068965517242, 12.75) |
| hamming | 3 | 9 | (0.5862068965517242, 10.2) |
| armstrong-numbers | 3 | 10 | (0.5862068965517242, 8.5) |
| proverb | 3 | 9 | (0.5862068965517242, 12.75) |
| pascals-triangle | 3 | 15 | (0.5862068965517242, 12.75) |
| rotational-cipher | 3 | 13 | (0.5862068965517242, 12.75) |
| resistor-color-trio | 3 | 15 | (0.5862068965517242, 8.5) |
| diamond | 3 | 13 | (0.5862068965517242, 7.285714285714285) |
| bob | 3 | 14 | (0.5862068965517242, 12.75) |
| darts | 3 | 9 | (0.5862068965517242, 25.5) |
| high-scores | 4 | 9 | (0.5862068965517242, 25.5) |
| secret-handshake | 4 | 13 | (0.5862068965517242, 17.0) |
| series | 4 | 12 | (0.5862068965517242, 12.75) |
| luhn | 4 | 20 | (0.5862068965517242, 8.5) |
| pangram | 4 | 11 | (0.5862068965517242, 17.0) |
| perfect-numbers | 4 | 16 | (0.5862068965517242, 12.75) |
| space-age | 4 | 8 | (0.5862068965517242, 51.0) |
| isogram | 4 | 11 | (0.5862068965517242, 17.0) |
| protein-translation | 4 | 17 | (0.5862068965517242, 12.75) |
| sum-of-multiples | 5 | 16 | (0.5862068965517242, 17.0) |
| flatten-array | 5 | 7 | (0.5862068965517242, 51.0) |
| bottle-song | 5 | 20 | (0.5862068965517242, 17.0) |
| largest-series-product | 5 | 15 | (0.5862068965517242, 25.5) |
| allergies | 5 | 7 | (1.02, 51.0) |
| square-root | 5 | 10 | (0.5862068965517242, 51.0) |
| raindrops | 5 | 13 | (0.5862068965517242, 51.0) |
| anagram | 6 | 15 | (0.5862068965517242, 51.0) |
| atbash-cipher | 6 | 24 | (0.5862068965517242, 12.75) |
| twelve-days | 6 | 16 | (0.5862068965517242, 51.0) |
| food-chain | 7 | 26 | (0.5862068965517242, 25.5) |
| roman-numerals | 7 | 11 | (1.02, 51.0) |
| crypto-square | 7 | 23 | (0.5862068965517242, 25.5) |
| run-length-encoding | 7 | 27 | (0.5862068965517242, 17.0) |
| simple-cipher | 9 | 15 | (1.2142857142857144, 51.0) |
| saddle-points | 9 | 18 | (1.2142857142857144, 51.0) |

As you wrote most of those exercises, what do you think about this ranking @ErikSchierboom?