### PR TITLE
docs(test): fix uiua testing instructions

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -7,7 +7,7 @@ However, modifying tests does not affect the online test-runner process.
 
 ## Local Testing
 
-To runs an exercise's tests, open a terminal in the exercise's directory and run the `uiua tests tests.ua` command.
+To runs an exercise's tests, open a terminal in the exercise's directory and run the `uiua test tests.ua` command.
 
 For example, the output of an unedited `hello-world` exercise might look like this:
 


### PR DESCRIPTION
the TESTS.md says that to run tests, you're supposed to use `uiua tests tests.ua` but (at least on v0.13.0) the correct command is `uiua test tests.ua`