### PR TITLE
Fix some signature comments that didn't match with the tests

### DIFF
--- a/exercises/practice/affine-cipher/affine-cipher.ua
+++ b/exercises/practice/affine-cipher/affine-cipher.ua
@@ -1,7 +1,7 @@
 # Encode plaintext using the Affine Cipher
-# Ciphertext ? Key Plaintext
+# Ciphertext ? PlainText KeyA KeyB
 Encode ← |3 ⊙⋅⋅(⍤ "Please implement Encode" 0)
 
 # Decode plaintext using the Affine Cipher
-# Plaintext ? Key Ciphertext
+# Plaintext ? CypherText KeyA KeyB
 Decode ← |3 ⊙⋅⋅(⍤ "Please implement Decode" 0)

--- a/exercises/practice/clock/clock.ua
+++ b/exercises/practice/clock/clock.ua
@@ -4,11 +4,11 @@
   New ← |2 ⊙⋅(⍤ "Please implement New" 0)
   
   # Add minutes to a clock
-  # Clock ? Clock Minutes
+  # Clock ? Minutes Clock
   Add ← |2 ⊙⋅(⍤ "Please implement Add" 0)
   
   # Subtract minutes to a clock
-  # Clock ? Clock Minutes
+  # Clock ? Minutes Clock
   Sub ← |2 ⊙⋅(⍤ "Please implement Sub" 0)
   
   # Return a clock's time formatted as a string


### PR DESCRIPTION
We noticed Clock and Affine Cipher's given signature comments did not match up with the test cases, this puts them in the right order and amount