### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/flatten-array/.docs/instructions.append.md
+++ b/exercises/practice/flatten-array/.docs/instructions.append.md
@@ -1,4 +1,6 @@
 # Instructions append
 
+## Implementation
+
 As Uiua does not have `null`, we've replaced them with `∞` (`infinity`) values.
 You should therefore flatten the array _and_ remove the `∞` values.

--- a/exercises/practice/forth/.docs/instructions.append.md
+++ b/exercises/practice/forth/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 ```exercism/note
 As Uiua does _not_ support putting functions on the stack, you won't be implementing user-defined words.
 ```

--- a/exercises/practice/queen-attack/.docs/instructions.append.md
+++ b/exercises/practice/queen-attack/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 This exercises uses [modules as functions](https://www.uiua.org/tutorial/modules#modules-as-functions) for a nice way to group functions that work on the same type of data (queens on a chessboard in this case).

--- a/exercises/practice/robot-name/.docs/instructions.append.md
+++ b/exercises/practice/robot-name/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 ```exercism/note
 As Uiua does **not** have mutable state, the exercise only expects you to generate random names.
 ```

--- a/exercises/practice/strain/.docs/instructions.append.md
+++ b/exercises/practice/strain/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 This exercise requires you to call a function that is passed in as an argument.
 In Uiua, you can do this via [macros](https://www.uiua.org/tutorial/macros), which is how this exercise expects you to solve it.
 


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.